### PR TITLE
Update copyright header to Expedia Group, Inc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ doesn't comply with the license).
 
 ### Apache header:
 
-    Copyright 2019 Expedia, Inc
+    Copyright 2019 Expedia Group, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Fixes
Update the template copyright header to the appropriate company name
