### PR TITLE
Use a placeholder for the year in the license header snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ doesn't comply with the license). Test files are considered source code.
 
 ### Apache header
 
-    Copyright 2021 Expedia, Inc.
+    Copyright [yyyy] Expedia, Inc.  <-- Remember to replace with the current year here
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
### :pencil: Description

Use a placeholder for the year in the license header snippet, with a warning message that remembers to replace it. This is to avoid it from becoming outdated and wrongly suggesting developers to use an old year.